### PR TITLE
Allow transformers-0.5

### DIFF
--- a/wizards.cabal
+++ b/wizards.cabal
@@ -83,8 +83,8 @@ Library
   Extensions: OverlappingInstances                   
   
   -- Packages needed in order to build this package.
-  Build-depends: base == 4.*, haskeline >= 0.6 && < 0.8, mtl >= 2.0 && < 2.3, transformers >= 0.1 && < 0.5, control-monad-free >= 0.5 && < 0.7, containers >= 0.4 && < 0.6
-  
+  Build-depends: base == 4.*, haskeline >= 0.6 && < 0.8, mtl >= 2.0 && < 2.3, transformers >= 0.1 && < 0.6, control-monad-free >= 0.5 && < 0.7, containers >= 0.4 && < 0.6
+
   -- Modules not exported by this package.
   -- Other-modules:       
   


### PR DESCRIPTION
This is necessary for GHC 8 support so it would be great if you could make a release after merging this.