### PR TITLE
Require Cabal-version 1.8

### DIFF
--- a/wizards.cabal
+++ b/wizards.cabal
@@ -61,7 +61,7 @@ Build-type:          Simple
 -- Extra-source-files:  
 
 -- Constraint on the version of Cabal needed to build this package.
-Cabal-version:       >=1.6
+Cabal-version:       >=1.8
 
 source-repository head
    type:     git   


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: wizards.cabal:86:50: version operators used. To use version operators
the package needs to specify at least 'cabal-version: >= 1.8'.
```